### PR TITLE
Add setting to turn off crits and accuracy

### DIFF
--- a/src/main/java/dk/sdu/mmmi/Main.java
+++ b/src/main/java/dk/sdu/mmmi/Main.java
@@ -31,6 +31,7 @@ public class Main {
         var settings  = new Settings();
         var monsterRegistry = new MonsterRegistry();
         var battleMonsterProcessor = new BattleMonsterProcessor();
+        battleMonsterProcessor.setSettings(settings);
 
         var battleAI = new dk.sdu.mmmi.modulemon.BattleAI.BattleAIFactory();
         battleAI.setSettingsService(settings);

--- a/src/main/java/dk/sdu/mmmi/modulemon/Game.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/Game.java
@@ -188,6 +188,9 @@ public class Game implements ApplicationListener {
             if(settings.getSetting(SettingsRegistry.getInstance().getNonDeterminism()) == null){
                 settings.setSetting(SettingsRegistry.getInstance().getNonDeterminism(), true);
             }
+            if(settings.getSetting(SettingsRegistry.getInstance().getConcurrentBattleAmount()) == null){
+                settings.setSetting(SettingsRegistry.getInstance().getConcurrentBattleAmount(), 5);
+            }
             gvm.setSettings(settings);
         });
     }

--- a/src/main/java/dk/sdu/mmmi/modulemon/Game.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/Game.java
@@ -185,6 +185,9 @@ public class Game implements ApplicationListener {
             if (settings.getSetting(SettingsRegistry.getInstance().getBattleAISetting()) == null){
                 settings.setSetting(SettingsRegistry.getInstance().getBattleAISetting(), "MCTS");
             }
+            if(settings.getSetting(SettingsRegistry.getInstance().getNonDeterminism()) == null){
+                settings.setSetting(SettingsRegistry.getInstance().getNonDeterminism(), true);
+            }
             gvm.setSettings(settings);
         });
     }

--- a/src/main/java/dk/sdu/mmmi/modulemon/HeadlessBattleView/HeadlessBattleView.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/HeadlessBattleView/HeadlessBattleView.java
@@ -315,6 +315,7 @@ public class HeadlessBattleView implements IGameViewService {
 
         var battleSim = new BattleSimulation();
         var processor = new BattleMonsterProcessor();
+        processor.setSettings(settings);
         battleSim.setMonsterProcessor(processor);
         battleSim.setPlayerAIFactory(teamAAI);
         battleSim.setOpponentAIFactory(teamBAI);

--- a/src/main/java/dk/sdu/mmmi/modulemon/HeadlessBattleView/HeadlessBattleView.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/HeadlessBattleView/HeadlessBattleView.java
@@ -77,6 +77,7 @@ public class HeadlessBattleView implements IGameViewService {
 
         scene = new HeadlessBattleScene(settings);
         battlingScene = new HeadlessBattlingScene();
+        concurrentBattles = (int) settings.getSetting(settingsRegistry.getConcurrentBattleAmount());
     }
 
     @Override

--- a/src/main/java/dk/sdu/mmmi/modulemon/Monster/BattleMonsterProcessor.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/Monster/BattleMonsterProcessor.java
@@ -119,7 +119,7 @@ public class BattleMonsterProcessor implements IBattleMonsterProcessor {
         //Generate random number between 0-255
         float randomVal = random.nextInt(256);
         //true if the generated number is less than the threshold
-        boolean criticalHit = randomVal >= threshold;
+        boolean criticalHit = randomVal < threshold;
 
         if (criticalHit) {
             System.out.println("critical hit");

--- a/src/main/java/dk/sdu/mmmi/modulemon/Monster/BattleMonsterProcessor.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/Monster/BattleMonsterProcessor.java
@@ -3,10 +3,15 @@ package dk.sdu.mmmi.modulemon.Monster;
 import dk.sdu.mmmi.modulemon.CommonBattleSimulation.IBattleMonsterProcessor;
 import dk.sdu.mmmi.modulemon.CommonMonster.IMonster;
 import dk.sdu.mmmi.modulemon.CommonMonster.IMonsterMove;
+import dk.sdu.mmmi.modulemon.Settings.Settings;
+import dk.sdu.mmmi.modulemon.common.SettingsRegistry;
+import dk.sdu.mmmi.modulemon.common.services.IGameSettings;
 
 import java.util.Random;
 
 public class BattleMonsterProcessor implements IBattleMonsterProcessor {
+
+    private IGameSettings settings;
 
     @Override
     public IMonster whichMonsterStarts(IMonster iMonster1, IMonster iMonster2) {
@@ -24,7 +29,9 @@ public class BattleMonsterProcessor implements IBattleMonsterProcessor {
         float sourceAttack = (float) source.getAttack();
         float targetDefence = (float) target.getDefence();
 
-        if (!doAccuracyHit(move.getAccuracy())) { return 0; }
+        boolean shouldUseNonDeterminism = (Boolean) settings.getSetting(SettingsRegistry.getInstance().getNonDeterminism());
+
+        if (!doAccuracyHit(move.getAccuracy()) && shouldUseNonDeterminism) { return 0; }
         // Same type attack bonus. Effectively the same as STAB in that other game
         boolean same_attack_type = source.getMonsterType() == move.getType();
         float attack_bonus = 1;
@@ -35,7 +42,10 @@ public class BattleMonsterProcessor implements IBattleMonsterProcessor {
 
         float monsterAttackDefence = (0.2f * sourceAttack + 3 + 20 ) / (targetDefence + 50);
 
-        int damage =  Math.round( monsterAttackDefence * moveDamage * attack_bonus * calculateTypeAdvantage(move.getType(), target.getMonsterType()) * calculateCriticalHit(source) );
+        int damage =  Math.round( monsterAttackDefence * moveDamage * attack_bonus * calculateTypeAdvantage(move.getType(), target.getMonsterType()));
+        if(shouldUseNonDeterminism){
+            damage *= calculateCriticalHit(source);
+        }
         return damage;
     }
 
@@ -125,5 +135,9 @@ public class BattleMonsterProcessor implements IBattleMonsterProcessor {
         //Ensures that the next move will always be below our factor and between(0-1)
         return random.nextFloat() <= factor;
 
+    }
+
+    public void setSettings(IGameSettings settings) {
+        this.settings = settings;
     }
 }

--- a/src/main/java/dk/sdu/mmmi/modulemon/common/SettingsRegistry.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/common/SettingsRegistry.java
@@ -18,6 +18,7 @@ public class SettingsRegistry {
     private UUID rectangle_style = UUID.randomUUID();
     private UUID battle_theme = UUID.randomUUID();
     private UUID battle_AI = UUID.randomUUID();
+    private UUID non_determinism = UUID.randomUUID();
 
     private SettingsRegistry(){
         settingsMap = new HashMap<>();
@@ -39,6 +40,7 @@ public class SettingsRegistry {
         settingsMap.put(rectangle_style, "personaRectangles");
         settingsMap.put(battle_theme, "battleMusicTheme");
         settingsMap.put(battle_AI, "AI");
+        settingsMap.put(non_determinism, "Nondeterminism");
     }
 
     /*
@@ -74,6 +76,9 @@ public class SettingsRegistry {
 
     public String getBattleAISetting() { return settingsMap.get(battle_AI); }
 
+    public String getNonDeterminism() {
+        return settingsMap.get(non_determinism);
+    }
 
     public static SettingsRegistry getInstance(){
         if(instance == null){

--- a/src/main/java/dk/sdu/mmmi/modulemon/common/SettingsRegistry.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/common/SettingsRegistry.java
@@ -19,6 +19,7 @@ public class SettingsRegistry {
     private UUID battle_theme = UUID.randomUUID();
     private UUID battle_AI = UUID.randomUUID();
     private UUID non_determinism = UUID.randomUUID();
+    private UUID concurrent_battles = UUID.randomUUID();
 
     private SettingsRegistry(){
         settingsMap = new HashMap<>();
@@ -41,6 +42,7 @@ public class SettingsRegistry {
         settingsMap.put(battle_theme, "battleMusicTheme");
         settingsMap.put(battle_AI, "AI");
         settingsMap.put(non_determinism, "Nondeterminism");
+        settingsMap.put(concurrent_battles, "Concurrent Battles");
     }
 
     /*
@@ -78,6 +80,9 @@ public class SettingsRegistry {
 
     public String getNonDeterminism() {
         return settingsMap.get(non_determinism);
+    }
+    public String getConcurrentBattleAmount() {
+        return settingsMap.get(concurrent_battles);
     }
 
     public static SettingsRegistry getInstance(){

--- a/src/main/java/dk/sdu/mmmi/modulemon/gameviews/MenuView.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/gameviews/MenuView.java
@@ -74,6 +74,7 @@ public class MenuView implements IGameViewService {
             "Battle Music Theme",
             "AI",
             "Use AI knowledge states",
+            "Nondeterminism"
     };
 
     private int AIIndex = 0;
@@ -213,7 +214,7 @@ public class MenuView implements IGameViewService {
                 (Game.HEIGHT - glyphLayout.height) / 1.25f
         );
 
-        if(!subtitle.isBlank()) {
+        if (!subtitle.isBlank()) {
             subtitleFont.setColor(Color.valueOf("ffcb05"));
             glyphLayout.setText(subtitleFont, subtitle);
             subtitleFont.draw(
@@ -278,6 +279,9 @@ public class MenuView implements IGameViewService {
 
     @Override
     public void handleInput(GameData gameData, IGameViewManager gameViewManager) {
+        if (gameData.getKeys().isPressed(GameKeys.BACK)) {
+            goBackToMainMenu();
+        }
         // Moves up in the menu
         if (gameData.getKeys().isPressed(GameKeys.UP)) {
             if (currentOption > 0) {
@@ -316,10 +320,7 @@ public class MenuView implements IGameViewService {
      */
     private void selectOption(IGameViewManager gvm) {
         if (menuOptions[currentOption].equalsIgnoreCase("GO BACK")) {
-            currentMenuState = MenuStates.DEFAULT;
-            currentOption = 0;
-            showSettings = false;
-            chooseSound.play(getSoundVolumeAsFloat());
+            goBackToMainMenu();
             return;
         }
 
@@ -353,6 +354,14 @@ public class MenuView implements IGameViewService {
                 Gdx.app.exit();
             }
         }
+    }
+
+    private void goBackToMainMenu() {
+        currentMenuState = MenuStates.DEFAULT;
+        currentOption = 0;
+        showSettings = false;
+        chooseSound.play(getSoundVolumeAsFloat());
+        return;
     }
 
     /**
@@ -408,7 +417,7 @@ public class MenuView implements IGameViewService {
                         break;
                     }
 
-                    if(menuOptions[currentOption].equalsIgnoreCase("AI")){
+                    if (menuOptions[currentOption].equalsIgnoreCase("AI")) {
                         AIIndex++;
 
                         AIIndex = AIIndex % AIOptions.length;
@@ -483,7 +492,7 @@ public class MenuView implements IGameViewService {
                     }
 
 
-                    if(menuOptions[currentOption].equalsIgnoreCase("AI")){
+                    if (menuOptions[currentOption].equalsIgnoreCase("AI")) {
                         if (AIIndex == 0) {
                             AIIndex = AIOptions.length - 1;
                         } else {
@@ -574,6 +583,18 @@ public class MenuView implements IGameViewService {
                     settings.setSetting(settingsRegistry.getAIKnowlegdeStateEnabled(), true);
                 }
                 chooseSound.play(getSoundVolumeAsFloat());
+            } else if (menuOptions[currentOption].equalsIgnoreCase("Nondeterminism")) {
+                /*
+                If setting for using nondeterminism for battles,
+                 */
+                if (((Boolean) settings.getSetting(settingsRegistry.getNonDeterminism()))) {
+                    settingsValueList.set(8, "Off");
+                    settings.setSetting(settingsRegistry.getNonDeterminism(), false);
+                } else {
+                    settingsValueList.set(8, "On");
+                    settings.setSetting(settingsRegistry.getNonDeterminism(), true);
+                }
+                chooseSound.play(getSoundVolumeAsFloat());
             }
         }
     }
@@ -604,6 +625,7 @@ public class MenuView implements IGameViewService {
 
             settingsValueList.add((Boolean) settings.getSetting(settingsRegistry.getAIKnowlegdeStateEnabled()) ? "On" : "Off");
             AIIndex = Arrays.asList(AIOptions).indexOf(AI);
+            settingsValueList.add((Boolean) settings.getSetting(settingsRegistry.getNonDeterminism()) ? "On" : "Off");
         }
     }
 

--- a/src/main/java/dk/sdu/mmmi/modulemon/gameviews/MenuView.java
+++ b/src/main/java/dk/sdu/mmmi/modulemon/gameviews/MenuView.java
@@ -74,7 +74,8 @@ public class MenuView implements IGameViewService {
             "Battle Music Theme",
             "AI",
             "Use AI knowledge states",
-            "Nondeterminism"
+            "Nondeterminism",
+            "Concurrent battle amount"
     };
 
     private int AIIndex = 0;
@@ -445,6 +446,20 @@ public class MenuView implements IGameViewService {
                         chooseSound.play(getSoundVolumeAsFloat());
                         break;
                     }
+
+                    if (menuOptions[currentOption].equalsIgnoreCase("Concurrent battle amount")) {
+                        // Sets the maximum concurrent battles to 10
+                        if (((int) settings.getSetting(settingsRegistry.getConcurrentBattleAmount()) < 16)) {
+                            // increases the concurrent battles by 1
+                            int concurrentBattles = (int) settings.getSetting(settingsRegistry.getConcurrentBattleAmount()) + 1;
+                            settings.setSetting(settingsRegistry.getConcurrentBattleAmount(), concurrentBattles);
+
+                            settingsValueList.set(9, String.valueOf(concurrentBattles));
+                            chooseSound.play(getSoundVolumeAsFloat());
+                        }
+                        break;
+                    }
+
                     boolean_settings_switch_on_off();
                     break;
                 }
@@ -523,6 +538,19 @@ public class MenuView implements IGameViewService {
                         settingsValueList.set(5, battleTheme);
 
                         chooseSound.play(getSoundVolumeAsFloat());
+                        break;
+                    }
+
+                    if (menuOptions[currentOption].equalsIgnoreCase("Concurrent battle amount")) {
+                        // Sets the minimum concurrent battles to 1
+                        if (((int) settings.getSetting(settingsRegistry.getConcurrentBattleAmount()) > 1)) {
+                            // Decreases the concurrent battles by 1
+                            int concurrentBattles = (int) settings.getSetting(settingsRegistry.getConcurrentBattleAmount()) - 1;
+                            settings.setSetting(settingsRegistry.getConcurrentBattleAmount(), concurrentBattles);
+
+                            settingsValueList.set(9, String.valueOf(concurrentBattles));
+                            chooseSound.play(getSoundVolumeAsFloat());
+                        }
                         break;
                     }
 
@@ -626,6 +654,8 @@ public class MenuView implements IGameViewService {
             settingsValueList.add((Boolean) settings.getSetting(settingsRegistry.getAIKnowlegdeStateEnabled()) ? "On" : "Off");
             AIIndex = Arrays.asList(AIOptions).indexOf(AI);
             settingsValueList.add((Boolean) settings.getSetting(settingsRegistry.getNonDeterminism()) ? "On" : "Off");
+            var battleAmount = String.valueOf(settings.getSetting(settingsRegistry.getConcurrentBattleAmount()));
+            settingsValueList.add(battleAmount);
         }
     }
 


### PR DESCRIPTION
Closes #24.
When "Nondeterminism" is turned off, crits and accuracy will not be taken into account in battles.

Also made it possible to use `ESC` to go back to the main menu from settings or choosing play mode.